### PR TITLE
Nagger for charts to enable ASO upgrade

### DIFF
--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -41,11 +41,11 @@ helm:
     version: "1.3.0"
     date_deadline: "2024-06-30"
   blobstorage:
-    version: "1.0.1"
-    date_deadline: "2023-08-13"
+    version: "2.0.1"
+    date_deadline: "2024-07-30"
   servicebus:
-    version: "1.0.4"
-    date_deadline: "2023-08-13"
+    version: "1.0.6"
+    date_deadline: "2024-07-30"
   ccd:
     version: "8.0.27"
     date_deadline: "2023-03-29"


### PR DESCRIPTION
For v2.4 ASO+, teams must use v1api resources (v1beta is removed from v2.3+)

This is for blobstorage and servicebus charts

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
