### PR TITLE
Updating action to help with stability

### DIFF
--- a/scripts/dependency-versions.sh
+++ b/scripts/dependency-versions.sh
@@ -134,6 +134,7 @@ create_branch() {
         upgrades=""
 
         git checkout master
+        git pull
         git checkout -b $branch
         
         # loop minor_upgrades entries & split key on _ deliminater to get key & subkey
@@ -174,6 +175,7 @@ create_branch() {
             fi
 
             branch="$key-$component_name-major-update"
+            git pull
             git checkout -b "$branch"
 
             # update nagger versions yaml with new version


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24067

### Change description
While looking at updating the nagger for DTSPO-24067, it looks like the github action is broken due to an outstanding PR.

As a way to try help avoid a similar issue in the future I want to update the script to add in an additional pull that should help avoid branch conflicts.
End goal is to make the action a bit smoother. 

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
