### PR TITLE
Updating nagger for oci charts

### DIFF
--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -34,32 +34,32 @@ terraform:
     release_api: "https://api.github.com/repos/PaloAltoNetworks/terraform-provider-panos/releases"
 helm:
   java:
-    version: "5.2.0"
-    date_deadline: "2024-06-30"
+    version: "5.3.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-java/releases"
   nodejs:
-    version: "3.1.0"
-    date_deadline: "2024-06-30"
+    version: "3.2.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-nodejs/releases"
   job:
-    version: "2.1.1"
-    date_deadline: "2024-01-24"
+    version: "2.2.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-job/releases"
   function:
-    version: "2.4.1"
-    date_deadline: "2023-10-23"
+    version: "2.6.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-function/releases"
   base:
-    version: "1.3.0"
-    date_deadline: "2024-06-30"
+    version: "1.4.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-base/releases"
   blobstorage:
-    version: "2.0.1"
-    date_deadline: "2024-07-30"
+    version: "2.1.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-blobstorage/releases"
   servicebus:
-    version: "1.0.6"
-    date_deadline: "2024-07-30"
+    version: "1.1.0"
+    date_deadline: "2025-03-31"
     release_api: "https://api.github.com/repos/hmcts/chart-servicebus/releases"
   ccd:
     version: "8.0.27"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24307

### Change description
Updating nagger for the new OCI helm charts that have been released over the last 2 weeks. 

Nagger set for end of March for teams to update

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
